### PR TITLE
feat: options for executing a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Options:
   -h, --help                          display help for command
 
 Commands:
-  complete [options] [reminder...]    Complete a reminder.
+  complete [options] [query...]       Complete a reminder.
   daemon                              `remindd` daemon.
   info                                Prints information about the current installation.
   list [options]                      List the reminders.
   me <reminder...>                    Create a reminder.
-  remove [options] [reminder...]      Remove a reminder.
+  remove [options] [query...]         Remove a reminder.
   reschedule [options] <reminder...>  Reschedule a reminder.
   help [command]                      display help for command
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Usage: remind [options] [command]
 A natural language reminder CLI.
 
 Options:
+  -v, --version                       output the version number
   -h, --help                          display help for command
 
 Commands:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,11 +31,17 @@ program
     .command('complete')
     .description('Complete a reminder.')
     .argument('[reminder...]', 'The text of the reminder.')
-    .option('-s, --search', 'Renders an interactive fuzzy search prompt.')
+    .option('-s, --search', 'Renders an fuzzy search prompt.')
+    .option(
+        '-e, --execute <command>',
+        'A command used to search the list of reminders. The output of the command is the reminder to complete.'
+    )
     .action(async (reminderWords, options) => {
-        const { search = false } = options;
-        const reminderText = reminderWords.join(' ');
-        await complete(reminderText, { search });
+        const { execute: executeCommand, search = false } = options;
+        const reminderText = reminderWords.length
+            ? reminderWords.join(' ')
+            : undefined;
+        await complete(reminderText, { executeCommand, search });
     });
 
 const daemon = program.command('daemon').description('`remindd` daemon.');
@@ -96,11 +102,17 @@ program
     .command('remove')
     .description('Remove a reminder.')
     .argument('[reminder...]', 'The text of the reminder.')
-    .option('-s, --search', 'Renders an interactive fuzzy search prompt.')
+    .option('-s, --search', 'Renders an fuzzy search prompt.')
+    .option(
+        '-e, --execute <command>',
+        'A command used to search the list of reminders. The output of the command is the reminder to remove.'
+    )
     .action(async (reminderWords, options) => {
-        const { search = false } = options;
-        const reminderText = reminderWords.join(' ');
-        await remove(reminderText, { search });
+        const { execute: executeCommand, search = false } = options;
+        const reminderText = reminderWords.length
+            ? reminderWords.join(' ')
+            : undefined;
+        await remove(reminderText, { executeCommand, search });
     });
 
 program
@@ -110,11 +122,15 @@ program
         '<reminder...>',
         'The reminder information, including the date and time.'
     )
-    .option('-s, --search', 'Renders an interactive fuzzy search prompt.')
+    .option('-s, --search', 'Renders an fuzzy search prompt.')
+    .option(
+        '-e, --execute <command>',
+        'A command used to search the list of reminders. The output of the command is the reminder to reschedule. When using this option, only the date and time information in the <reminder...> argument will be used.'
+    )
     .action(async (reminderWords, options) => {
-        const { search = false } = options;
+        const { execute: executeCommand, search = false } = options;
         const reminderText = reminderWords.join(' ');
-        await reschedule(reminderText, { search });
+        await reschedule(reminderText, { executeCommand, search });
     });
 
 program.parse(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,18 +30,19 @@ program
 program
     .command('complete')
     .description('Complete a reminder.')
-    .argument('[reminder...]', 'The text of the reminder.')
+    .argument(
+        '[query...]',
+        "A full or partial match of the reminder's title or id."
+    )
     .option('-s, --search', 'Renders a fuzzy search prompt.')
     .option(
         '-e, --execute <command>',
         'A command used to search the list of reminders. The output of the command is the reminder to complete.'
     )
-    .action(async (reminderWords, options) => {
+    .action(async (queryWords, options) => {
         const { execute: executeCommand, search = false } = options;
-        const reminderText = reminderWords.length
-            ? reminderWords.join(' ')
-            : undefined;
-        await complete(reminderText, { executeCommand, search });
+        const query = queryWords.length ? queryWords.join(' ') : undefined;
+        await complete(query, { executeCommand, search });
     });
 
 const daemon = program.command('daemon').description('`remindd` daemon.');
@@ -101,18 +102,19 @@ program
 program
     .command('remove')
     .description('Remove a reminder.')
-    .argument('[reminder...]', 'The text of the reminder.')
+    .argument(
+        '[query...]',
+        "A full or partial match of the reminder's title or id."
+    )
     .option('-s, --search', 'Renders a fuzzy search prompt.')
     .option(
         '-e, --execute <command>',
         'A command used to search the list of reminders. The output of the command is the reminder to remove.'
     )
-    .action(async (reminderWords, options) => {
+    .action(async (queryWords, options) => {
         const { execute: executeCommand, search = false } = options;
-        const reminderText = reminderWords.length
-            ? reminderWords.join(' ')
-            : undefined;
-        await remove(reminderText, { executeCommand, search });
+        const query = queryWords.length ? queryWords.join(' ') : undefined;
+        await remove(query, { executeCommand, search });
     });
 
 program
@@ -120,7 +122,7 @@ program
     .description('Reschedule a reminder.')
     .argument(
         '<reminder...>',
-        'The reminder information, including the date and time.'
+        "A full or partial match of the reminder's title or id, as well as the date and/or time to reschedule to."
     )
     .option('-s, --search', 'Renders a fuzzy search prompt.')
     .option(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ program
     .command('complete')
     .description('Complete a reminder.')
     .argument('[reminder...]', 'The text of the reminder.')
-    .option('-s, --search', 'Renders an fuzzy search prompt.')
+    .option('-s, --search', 'Renders a fuzzy search prompt.')
     .option(
         '-e, --execute <command>',
         'A command used to search the list of reminders. The output of the command is the reminder to complete.'
@@ -102,7 +102,7 @@ program
     .command('remove')
     .description('Remove a reminder.')
     .argument('[reminder...]', 'The text of the reminder.')
-    .option('-s, --search', 'Renders an fuzzy search prompt.')
+    .option('-s, --search', 'Renders a fuzzy search prompt.')
     .option(
         '-e, --execute <command>',
         'A command used to search the list of reminders. The output of the command is the reminder to remove.'
@@ -122,7 +122,7 @@ program
         '<reminder...>',
         'The reminder information, including the date and time.'
     )
-    .option('-s, --search', 'Renders an fuzzy search prompt.')
+    .option('-s, --search', 'Renders a fuzzy search prompt.')
     .option(
         '-e, --execute <command>',
         'A command used to search the list of reminders. The output of the command is the reminder to reschedule. When using this option, only the date and time information in the <reminder...> argument will be used.'

--- a/src/commands/complete.ts
+++ b/src/commands/complete.ts
@@ -1,14 +1,16 @@
+import execute from '../execute.js';
 import getFormatter, { FormattableRecord } from '../format.js';
 import { record as recordPrompt } from '../prompts/index.js';
 import makeSearcher from '../search.js';
 import store, { Record } from '../store/index.js';
 
 type Options = {
+    executeCommand?: string;
     search: boolean;
 };
 
 const complete = async (
-    searchText: string,
+    reminderText: string | undefined,
     options: Options
 ): Promise<void> => {
     const records = await store.getIncomplete();
@@ -20,15 +22,24 @@ const complete = async (
 
     let record;
     if (options.search) {
-        record = await recordPrompt(searchText, records);
+        record = await recordPrompt(reminderText || '', records);
+        if (!record) {
+            return;
+        }
+    } else if (options.executeCommand) {
+        record = await execute(options.executeCommand, records);
         if (!record) {
             return;
         }
     } else {
+        if (!reminderText) {
+            throw new Error('No reminder provided.');
+        }
+
         const toString = (record: Record) =>
             format(new FormattableRecord(record));
         const search = makeSearcher(records, toString);
-        const results = search(searchText);
+        const results = search(reminderText);
         if (!results.length) {
             throw new Error('No match found.');
         } else if (results.length > 1) {

--- a/src/commands/complete.ts
+++ b/src/commands/complete.ts
@@ -10,7 +10,7 @@ type Options = {
 };
 
 const complete = async (
-    reminderText: string | undefined,
+    query: string | undefined,
     options: Options
 ): Promise<void> => {
     const records = await store.getIncomplete();
@@ -20,7 +20,7 @@ const complete = async (
 
     let record;
     if (options.search) {
-        record = await recordPrompt(reminderText || '', records);
+        record = await recordPrompt(query || '', records);
         if (!record) {
             return;
         }
@@ -30,12 +30,12 @@ const complete = async (
             return;
         }
     } else {
-        if (!reminderText) {
-            throw new Error('No reminder provided.');
+        if (!query) {
+            throw new Error('No query provided.');
         }
 
         const search = makeSearcher(records);
-        const results = search(reminderText);
+        const results = search(query);
         if (!results.length) {
             throw new Error('No match found.');
         } else if (results.length > 1) {

--- a/src/commands/complete.ts
+++ b/src/commands/complete.ts
@@ -2,7 +2,7 @@ import execute from '../execute.js';
 import getFormatter, { FormattableRecord } from '../format.js';
 import { record as recordPrompt } from '../prompts/index.js';
 import makeSearcher from '../search.js';
-import store, { Record } from '../store/index.js';
+import store from '../store/index.js';
 
 type Options = {
     executeCommand?: string;
@@ -17,8 +17,6 @@ const complete = async (
     if (!records.length) {
         throw new Error('There are no reminders.');
     }
-
-    const format = getFormatter();
 
     let record;
     if (options.search) {
@@ -36,9 +34,7 @@ const complete = async (
             throw new Error('No reminder provided.');
         }
 
-        const toString = (record: Record) =>
-            format(new FormattableRecord(record));
-        const search = makeSearcher(records, toString);
+        const search = makeSearcher(records);
         const results = search(reminderText);
         if (!results.length) {
             throw new Error('No match found.');
@@ -51,6 +47,7 @@ const complete = async (
 
     await store.complete(record);
 
+    const format = getFormatter();
     const formattableRecord = new FormattableRecord(record);
     const recordText = format(formattableRecord);
     const output = `Reminder completed.\n${recordText}`;

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -2,7 +2,7 @@ import execute from '../execute.js';
 import getFormatter, { FormattableRecord } from '../format.js';
 import { record as recordPrompt } from '../prompts/index.js';
 import makeSearcher from '../search.js';
-import store, { Record } from '../store/index.js';
+import store from '../store/index.js';
 
 type Options = {
     executeCommand?: string;
@@ -17,8 +17,6 @@ const remove = async (
     if (!records.length) {
         throw new Error('There are no reminders.');
     }
-
-    const format = getFormatter();
 
     let record;
     if (options.search) {
@@ -36,9 +34,7 @@ const remove = async (
             throw new Error('No reminder provided.');
         }
 
-        const toString = (record: Record) =>
-            format(new FormattableRecord(record));
-        const search = makeSearcher(records, toString);
+        const search = makeSearcher(records);
         const results = search(reminderText);
         if (!results.length) {
             throw new Error('No match found.');
@@ -51,6 +47,7 @@ const remove = async (
 
     await store.remove(record);
 
+    const format = getFormatter();
     const formattableRecord = new FormattableRecord(record);
     const recordText = format(formattableRecord);
     const output = `Reminder removed.\n${recordText}`;

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -10,7 +10,7 @@ type Options = {
 };
 
 const remove = async (
-    reminderText: string | undefined,
+    query: string | undefined,
     options: Options
 ): Promise<void> => {
     const records = await store.getIncomplete();
@@ -20,7 +20,7 @@ const remove = async (
 
     let record;
     if (options.search) {
-        record = await recordPrompt(reminderText || '', records);
+        record = await recordPrompt(query || '', records);
         if (!record) {
             return;
         }
@@ -30,12 +30,12 @@ const remove = async (
             return;
         }
     } else {
-        if (!reminderText) {
-            throw new Error('No reminder provided.');
+        if (!query) {
+            throw new Error('No query provided.');
         }
 
         const search = makeSearcher(records);
-        const results = search(reminderText);
+        const results = search(query);
         if (!results.length) {
             throw new Error('No match found.');
         } else if (results.length > 1) {

--- a/src/commands/reschedule.ts
+++ b/src/commands/reschedule.ts
@@ -4,7 +4,7 @@ import execute from '../execute.js';
 import getFormatter, { FormattableRecord } from '../format.js';
 import { record as recordPrompt } from '../prompts/index.js';
 import makeSearcher from '../search.js';
-import store, { Record } from '../store/index.js';
+import store from '../store/index.js';
 
 type Options = {
     executeCommand?: string;
@@ -14,8 +14,6 @@ type Options = {
 const reschedule = async (text: string, options: Options): Promise<void> => {
     const { date, title: searchText } = remind(text);
     const records = await store.getIncomplete();
-
-    const format = getFormatter();
 
     let record;
     if (options.search) {
@@ -29,9 +27,7 @@ const reschedule = async (text: string, options: Options): Promise<void> => {
             return;
         }
     } else {
-        const toString = (record: Record) =>
-            format(new FormattableRecord(record));
-        const search = makeSearcher(records, toString);
+        const search = makeSearcher(records);
         const results = search(searchText);
         if (!results.length) {
             throw new Error('No match found.');
@@ -45,6 +41,7 @@ const reschedule = async (text: string, options: Options): Promise<void> => {
     record.reminder.date = date;
     await store.update(record);
 
+    const format = getFormatter();
     const formattableRecord = new FormattableRecord(record);
     const recordText = format(formattableRecord);
     const output = `Reminder rescheduled.\n${recordText}`;

--- a/src/commands/reschedule.ts
+++ b/src/commands/reschedule.ts
@@ -11,13 +11,16 @@ type Options = {
     search: boolean;
 };
 
-const reschedule = async (text: string, options: Options): Promise<void> => {
-    const { date, title: searchText } = remind(text);
+const reschedule = async (
+    reminderText: string,
+    options: Options
+): Promise<void> => {
+    const { date, title: query } = remind(reminderText);
     const records = await store.getIncomplete();
 
     let record;
     if (options.search) {
-        record = await recordPrompt(searchText, records);
+        record = await recordPrompt(query, records);
         if (!record) {
             return;
         }
@@ -27,8 +30,12 @@ const reschedule = async (text: string, options: Options): Promise<void> => {
             return;
         }
     } else {
+        if (!query) {
+            throw new Error('No query provided.');
+        }
+
         const search = makeSearcher(records);
-        const results = search(searchText);
+        const results = search(query);
         if (!results.length) {
             throw new Error('No match found.');
         } else if (results.length > 1) {

--- a/src/commands/reschedule.ts
+++ b/src/commands/reschedule.ts
@@ -1,11 +1,13 @@
 import remind from '@remindd/core';
 
+import execute from '../execute.js';
 import getFormatter, { FormattableRecord } from '../format.js';
 import { record as recordPrompt } from '../prompts/index.js';
 import makeSearcher from '../search.js';
 import store, { Record } from '../store/index.js';
 
 type Options = {
+    executeCommand?: string;
     search: boolean;
 };
 
@@ -18,6 +20,11 @@ const reschedule = async (text: string, options: Options): Promise<void> => {
     let record;
     if (options.search) {
         record = await recordPrompt(searchText, records);
+        if (!record) {
+            return;
+        }
+    } else if (options.executeCommand) {
+        record = await execute(options.executeCommand, records);
         if (!record) {
             return;
         }

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -1,0 +1,57 @@
+import childProcess from 'node:child_process';
+
+import getFormatter, { FormattableRecord } from './format.js';
+import { Record as StoreRecord } from './store/index.js';
+
+const execute = (
+    command: string,
+    records: StoreRecord[]
+): Promise<StoreRecord | undefined> => {
+    // Generate remind list text
+    const format = getFormatter();
+    const rowToRecord: Record<string, StoreRecord> = {};
+    const reminderListOutput =
+        records
+            .map((record) => {
+                const row = format(new FormattableRecord(record));
+                rowToRecord[row] = record;
+                return row;
+            })
+            .join('\n') + '\n';
+
+    // Execute command
+    const child = childProcess.spawn(command, {
+        shell: true,
+        stdio: ['pipe', 'pipe', 'inherit'],
+    });
+    child.stdin.write(reminderListOutput);
+    child.stdin.end();
+    return new Promise((resolve) => {
+        child.stdout.on('data', (data) => {
+            const output = data.toString().replace(/\r?\n/g, '');
+            const record = rowToRecord[output];
+            if (record) {
+                resolve(record);
+            }
+
+            const row = Object.keys(rowToRecord).find((row) =>
+                row.includes(output)
+            );
+            if (row) {
+                return rowToRecord[row];
+            }
+
+            throw new Error(
+                `No reminder was found matching the output:\n\n${data.toString()}`
+            );
+        });
+        child.on('error', (error) => {
+            throw new Error(`The command failed: "${error.message}"`);
+        });
+        child.on('close', () => {
+            resolve(undefined);
+        });
+    });
+};
+
+export default execute;

--- a/src/prompts/record.ts
+++ b/src/prompts/record.ts
@@ -42,9 +42,7 @@ class RecordPrompt {
         this.selectionIndex = 0;
         this.startIndex = 0;
         this.format = getFormatter();
-        const toString = (record: Record) =>
-            this.format(new FormattableRecord(record));
-        this.search = makeSearcher(this.records, toString);
+        this.search = makeSearcher(this.records);
     }
 
     keypress(input: string, keypress: Keypress): string | undefined {

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,5 +1,6 @@
 import { Fzf } from 'fzf';
 
+import getFormatter, { FormattableRecord } from './format.js';
 import { Record } from './store/index.js';
 
 type FzfSearchResult = {
@@ -21,9 +22,10 @@ type SearchResult = {
 };
 
 const makeSearcher = (
-    records: Record[],
-    toString: (record: Record) => string
+    records: Record[]
 ): ((query: string) => SearchResult[]) => {
+    const format = getFormatter();
+    const toString = (record: Record) => format(new FormattableRecord(record));
     const fzf = new Fzf(records, {
         selector: toString,
     });


### PR DESCRIPTION
New `-e/--execute` command that is used to run a user's command that will search the list of reminders and return the reminder to perform the action on (i.e., complete, remove or reschedule)